### PR TITLE
fixed export

### DIFF
--- a/commands/export/export_env_list.c
+++ b/commands/export/export_env_list.c
@@ -6,7 +6,7 @@
 /*   By: stakabay <stakabay@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/19 09:27:31 by stakabay          #+#    #+#             */
-/*   Updated: 2021/08/11 06:49:32 by stakabay         ###   ########.fr       */
+/*   Updated: 2021/08/23 06:21:41 by stakabay         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,13 +62,8 @@ char	**make_env_arr(t_env_list *list)
 	i = 0;
 	node = list->head;
 	env_arr = malloc_arr(node);
-	//merge_sort(&node);
-	// ndpr = list->head;
-	// while(ndpr->next)
-	// {
-	// 	printf("○○%s○○\n",ndpr->key);
-	// 	ndpr = ndpr->next;
-	// }
+	merge_sort(&node);
+	list->head = node;
 	while (node != NULL)
 	{
 		if (ft_strncmp(node->key, "_", 1) && ft_strncmp(node->key, "?", 1))

--- a/commands/export/ft_export.c
+++ b/commands/export/ft_export.c
@@ -6,7 +6,7 @@
 /*   By: stakabay <stakabay@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/24 22:25:20 by stakabay          #+#    #+#             */
-/*   Updated: 2021/08/11 06:57:37 by stakabay         ###   ########.fr       */
+/*   Updated: 2021/08/23 06:23:17 by stakabay         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,19 +70,18 @@ void	insert_node_to_list(t_env_list *list, t_env_node *node)
 	ndptr = serch_nodes(list, node->key);
 	if (ndptr == NULL)
 		insert_end(list, node);
-	else if (!ndptr->value && node->value)
+	else if (node->value)
 	{
 		ndptr->value = ft_strdup(node->value);
 		if (ndptr->value == NULL)
 			exit(malloc_error());
+		free(node);
 	}
-	free(node);
 }
 
 int	ft_export(char **argv, t_env_list *list)
 {
 	t_env_node	*node;
-	t_env_node	*ndpr;
 	int			renum;
 	int			i;
 

--- a/commands/export/mergesort.c
+++ b/commands/export/mergesort.c
@@ -6,7 +6,7 @@
 /*   By: stakabay <stakabay@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/25 08:37:56 by stakabay          #+#    #+#             */
-/*   Updated: 2021/08/11 06:48:54 by stakabay         ###   ########.fr       */
+/*   Updated: 2021/08/23 06:25:45 by stakabay         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,7 @@ t_env_node	*merge(t_env_node *a, t_env_node *b)
 	t_env_node	*result;
 	size_t		len;
 
+	result = NULL;
 	if (a == NULL)
 		return (b);
 	else if (b == NULL)
@@ -51,7 +52,7 @@ t_env_node	*merge(t_env_node *a, t_env_node *b)
 	*/
 
 void	merge_sort_rec(t_env_node *head,
-						t_env_node **headref, t_env_node **backref)
+						t_env_node **frontref, t_env_node **backref)
 {
 	t_env_node	*slow;
 	t_env_node	*fast;
@@ -67,7 +68,7 @@ void	merge_sort_rec(t_env_node *head,
 			fast = fast->next;
 		}
 	}
-	*headref = head;
+	*frontref = head;
 	*backref = slow->next;
 	slow->next = NULL;
 }

--- a/commands/util.c
+++ b/commands/util.c
@@ -26,7 +26,7 @@ t_env_node		*serch_nodes(t_env_list *list, char *keybuf)
 		if (!(ft_strncmp(ndptr->key, keybuf, ft_strlen(keybuf))))
 		{
 			//keyがリストの中にあった場合
-			if (ndptr->value)
+			//if (ndptr->value)
 				return (ndptr);
 		}
 		ndptr = ndptr->next;


### PR DESCRIPTION
【export】

1. Segmentation fault

    Case

     export XXX=xxx;
     export;
     export TEST=test;
     export;
     ⇨Segmentation fault. or just once.

    Cause
    might be due to while loop in malloc_arr(node);

    ```bash
    while (node != NULL)
    	{
    		write(1,"xxx\n",4);
    		envcount++;
    		node = node->next;
    	}
    ```

    The problem is probably "NULL is not set for new node's next"

    ⇨No.

    ■ Found out the cause

    I freed necessary node after I added it into the end of the list.

    ⇨Only freed if the key was already in the list.

    ```bash
    void	insert_node_to_list(t_env_list *list, t_env_node *node)
    {
    	t_env_node	*ndptr;

    	ndptr = serch_nodes(list, node->key);
    	if (ndptr == NULL)
    		insert_end(list, node);
    	else if (node->value)
    	{
    		ndptr->value = ft_strdup(node->value);
    		if (ndptr->value == NULL)
    			exit(malloc_error());
    		**_free(node);_**
    	}
    }
    ```

2. Only half of list is displayed

    I haven't changed list_head after merge sort...

    ```bash
    char	**make_env_arr(t_env_list *list)
    {
    	int			i;
    	char		**env_arr;
    	t_env_node	*node;
    	t_env_node	*ndpr;

    	i = 0;
    	node = list->head;
    	env_arr = malloc_arr(node);
    	merge_sort(&node);
    	**_list->head = node;_**
    	while (node != NULL)
    ```

3. If there is no value, add a separate node for the same key.

    ⇨When node hasn't value, search nodes() return NULL

    ⇨Modified search nodes in util as below.

```bash
	ndptr = list->head;
	while (ndptr)
	{
		if (!(ft_strncmp(ndptr->key, keybuf, ft_strlen(keybuf))))
		{
			//keyがリストの中にあった場合
			**_//if (ndptr->value)_**
				return (ndptr);
		}
		ndptr = ndptr->next;
	}
	return (NULL);
}
```